### PR TITLE
AOF channel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ _testmain.go
 bin
 pkg
 vendor/src
+test.log

--- a/src/server/domain.go
+++ b/src/server/domain.go
@@ -3,7 +3,6 @@ package server
 import (
 	"datamodel"
 	pb "datamodel/protobuf"
-	"fmt"
 
 	"storage"
 
@@ -31,10 +30,8 @@ func (s *serverStruct) createDomain(ctx context.Context, in *pb.Domain) (*pb.Dom
 }
 
 func (s *serverStruct) CreateDomain(ctx context.Context, in *pb.Domain) (*pb.Domain, error) {
-	if err := s.storage.AppendDomOp(storage.CreateDom, in); err != nil {
-		fmt.Println(err)
-	}
-	return s.createDomain(ctx, in)
+	s.storage.AppendDomOp(storage.CreateDom, in)
+	return &pb.Domain{}, nil
 }
 
 func (s *serverStruct) ListDomains(ctx context.Context, in *pb.Empty) (*pb.ListDomainsReply, error) {
@@ -54,10 +51,8 @@ func (s *serverStruct) deleteDomain(ctx context.Context, in *pb.Domain) (*pb.Emp
 }
 
 func (s *serverStruct) DeleteDomain(ctx context.Context, in *pb.Domain) (*pb.Empty, error) {
-	if err := s.storage.AppendDomOp(storage.DeleteDom, in); err != nil {
-		fmt.Println(err)
-	}
-	return s.deleteDomain(ctx, in)
+	s.storage.AppendDomOp(storage.DeleteDom, in)
+	return &pb.Empty{}, nil
 }
 
 func (s *serverStruct) GetDomain(ctx context.Context, in *pb.Domain) (*pb.Domain, error) {

--- a/src/server/sketch.go
+++ b/src/server/sketch.go
@@ -3,7 +3,6 @@ package server
 import (
 	"datamodel"
 	pb "datamodel/protobuf"
-	"fmt"
 	"storage"
 
 	"github.com/gogo/protobuf/proto"
@@ -19,10 +18,8 @@ func (s *serverStruct) createSketch(ctx context.Context, in *pb.Sketch) (*pb.Ske
 }
 
 func (s *serverStruct) CreateSketch(ctx context.Context, in *pb.Sketch) (*pb.Sketch, error) {
-	if err := s.storage.AppendSketchOp(storage.CreateSketch, in); err != nil {
-		fmt.Println(err)
-	}
-	return s.createSketch(ctx, in)
+	s.storage.AppendSketchOp(storage.CreateSketch, in)
+	return &pb.Sketch{}, nil
 }
 
 func (s *serverStruct) add(ctx context.Context, in *pb.AddRequest) (*pb.AddReply, error) {
@@ -45,10 +42,8 @@ func (s *serverStruct) add(ctx context.Context, in *pb.AddRequest) (*pb.AddReply
 }
 
 func (s *serverStruct) Add(ctx context.Context, in *pb.AddRequest) (*pb.AddReply, error) {
-	if err := s.storage.AppendAddOp(in); err != nil {
-		fmt.Println(err)
-	}
-	return s.add(ctx, in)
+	s.storage.AppendAddOp(in)
+	return &pb.AddReply{}, nil
 }
 
 func (s *serverStruct) GetMembership(ctx context.Context, in *pb.GetRequest) (*pb.GetMembershipReply, error) {
@@ -114,10 +109,8 @@ func (s *serverStruct) deleteSketch(ctx context.Context, in *pb.Sketch) (*pb.Emp
 }
 
 func (s *serverStruct) DeleteSketch(ctx context.Context, in *pb.Sketch) (*pb.Empty, error) {
-	if err := s.storage.AppendSketchOp(storage.DeleteSketch, in); err != nil {
-		fmt.Println(err)
-	}
-	return s.deleteSketch(ctx, in)
+	s.storage.AppendSketchOp(storage.DeleteSketch, in)
+	return &pb.Empty{}, nil
 }
 
 func (s *serverStruct) ListAll(ctx context.Context, in *pb.Empty) (*pb.ListReply, error) {

--- a/src/storage/aof.go
+++ b/src/storage/aof.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"sync"
 
 	"utils"
 
@@ -17,16 +16,36 @@ import (
 type AOF struct {
 	file   *os.File
 	buffer *bufio.ReadWriter
-	lock   sync.RWMutex
+
+	// writeChan takes entries, which are written to file
+	writeChan chan *Entry
+	// writeState gets set to false if writeChan is close to prevent panics
+	// when trying to put a value on a closed chan
+	writeState bool
+	// writtenRequest holds all successful requests
+	writtenChan chan *Entry
 }
 
 // NewAOF ...
 func NewAOF(path string) *AOF {
+	// Open or create file and create ReadWriter
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0600)
 	utils.PanicOnError(err)
-	rdr := bufio.NewReader(file)
-	wtr := bufio.NewWriter(file)
-	return &AOF{file, bufio.NewReadWriter(rdr, wtr), sync.RWMutex{}}
+	rwtr := bufio.NewReadWriter(
+		bufio.NewReader(file),
+		bufio.NewWriter(file),
+	)
+
+	// Create AOF
+	aof := &AOF{
+		file:        file,
+		buffer:      rwtr,
+		writeChan:   make(chan *Entry),
+		writeState:  true,
+		writtenChan: make(chan *Entry),
+	}
+
+	return aof
 }
 
 func (aof *AOF) write(e *Entry) error {
@@ -50,46 +69,70 @@ func createEntry(dom proto.Message) (*Entry, error) {
 	return &Entry{args: args}, nil
 }
 
+func (aof *AOF) queueWrite(e *Entry) {
+	if aof.writeState {
+		aof.writeChan <- e
+	}
+}
+
+// Run reads from the writeChan and executes write requests in order
+// If the writeChan is closed, this method exits as well
+func (aof *AOF) Run() {
+	for {
+		if e, more := <-aof.writeChan; more {
+			if err := aof.write(e); err == nil {
+				select {
+				case aof.writtenChan <- e:
+				default:
+				}
+			}
+		} else {
+			// Channel closed, bye
+			break
+		}
+	}
+}
+
+// WrittenChan returns the channel for written entries ro
+func (aof *AOF) WrittenChan() <-chan *Entry {
+	return aof.writtenChan
+}
+
 // AppendDomOp ...
-func (aof *AOF) AppendDomOp(op uint8, dom proto.Message) error {
-	aof.lock.Lock()
-	defer aof.lock.Unlock()
+func (aof *AOF) AppendDomOp(op uint8, dom proto.Message) {
 	e, err := createEntry(dom)
 	if err != nil {
-		return err
+		return // err
 	}
 	if op != CreateDom && op != DeleteDom {
-		return fmt.Errorf("No such op %d", op)
+		return // fmt.Errorf("No such op %d", op)
 	}
 	e.op = op
-	return aof.write(e)
+
+	aof.queueWrite(e)
 }
 
 // AppendSketchOp ...
-func (aof *AOF) AppendSketchOp(op uint8, sketch proto.Message) error {
-	aof.lock.Lock()
-	defer aof.lock.Unlock()
+func (aof *AOF) AppendSketchOp(op uint8, sketch proto.Message) {
 	e, err := createEntry(sketch)
 	if err != nil {
-		return err
+		return // err
 	}
 	e.op = op
 	if op != CreateSketch && op != DeleteSketch {
-		return fmt.Errorf("No such op %d", op)
+		return // fmt.Errorf("No such op %d", op)
 	}
-	return aof.write(e)
+	aof.queueWrite(e)
 }
 
 // AppendAddOp ...
-func (aof *AOF) AppendAddOp(add proto.Message) error {
-	aof.lock.Lock()
-	defer aof.lock.Unlock()
+func (aof *AOF) AppendAddOp(add proto.Message) {
 	args, err := proto.Marshal(add)
 	if err != nil {
-		return err
+		return // err
 	}
 	e := &Entry{Add, args}
-	return aof.write(e)
+	aof.queueWrite(e)
 }
 
 // Read ...
@@ -107,4 +150,10 @@ func (aof *AOF) Read() (*Entry, error) {
 	}
 	e := &Entry{uint8(op), []byte(msg)}
 	return e, nil
+}
+
+// Stop stops writing and waits until all write actions are finished
+func (aof *AOF) Stop() {
+	aof.writeState = false
+	close(aof.writeChan)
 }


### PR DESCRIPTION
This pr fixes #130.

**Edit:** The following changed over the discussion of this pr, please see the final commit 591b6cd for more details.

## Added
- `writeChan` for write requests
- `writeReq` struct to contain entry to write and error chan
- `writeQueue` func, which adds the entry to the queue and returns an error chan
- Asynchronous go func which receives items from the writeChannel and writes 
  them in order to the file 
- `Stop` func which stops writing and waits on items in the channel to finish write
- Tests for `Stop` func

## Removed
- `lock` mutex