### PR TITLE
Replace gb build|test with the go counterparts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+GOPATH=$(CURDIR):$(CURDIR)/vendor
+
 all:
-	@gb build
+	@GOPATH=$(GOPATH) && \
+	  go build -a -v -ldflags '-w' -o ./bin/skizze ./src/skizze
+	@GOPATH=$(GOPATH) && \
+	  go build -a -v -ldflags '-w' -o ./bin/skizze ./src/skizze-cli
 
 build-dep:
 	@go get github.com/constabulary/gb/...
@@ -8,7 +13,7 @@ vendor:
 	@gb vendor restore
 
 test:
-	@gb test -v
+	@GOPATH=$(GOPATH) && go test -v -race -cover ./src/...
 
 dist: build-dep vendor all
 


### PR DESCRIPTION
gb is now only used for vendoring.

Adavantages:
- Coverage per package
- More detailed output
- Detect race contitions

Drawbacks:
- Build doesn't skip (like gb build does)

Fixes #132 