### PR TITLE
Added check for empty array len. Fix #145

### DIFF
--- a/src/skizze-cli/bridge/loop.go
+++ b/src/skizze-cli/bridge/loop.go
@@ -57,7 +57,7 @@ func getFields(query string) []string {
 
 func evalutateQuery(query string) error {
 	fields := getFields(query)
-	if len(fields) <= 2 {
+	if len(fields) != 0 && len(fields) <= 2 {
 		//TODO: global stuff might be set
 		switch strings.ToLower(fields[0]) {
 		case "list":


### PR DESCRIPTION
The application now throws an "Invalid operation" when pressing (empty string) "Enter"