### PR TITLE
Added ctrl+d QUIT command. Fix #109

### DIFF
--- a/src/skizze-cli/bridge/loop.go
+++ b/src/skizze-cli/bridge/loop.go
@@ -17,7 +17,7 @@ import (
 	"datamodel"
 	pb "datamodel/protobuf"
 
-	"github.com/peterh/liner"
+	"github.com/martinpinto/liner"
 )
 
 var client pb.SkizzeClient
@@ -55,7 +55,7 @@ func getFields(query string) []string {
 	return fields
 }
 
-func evalutateQuery(query string) error {
+func evaluateQuery(query string) error {
 	fields := getFields(query)
 	if len(fields) != 0 && len(fields) <= 2 {
 		//TODO: global stuff might be set
@@ -124,14 +124,16 @@ func Run() {
 
 	for {
 		if query, err := line.Prompt("skizze> "); err == nil {
-			if err := evalutateQuery(query); err != nil {
+			if err := evaluateQuery(query); err != nil {
 				log.Printf("Error evaluating query: %s", err.Error())
 			}
 			line.AppendHistory(query)
-		} else if err == liner.ErrPromptAborted {
-			log.Printf("Aborted")
+		} else if err == io.EOF {
+			log.Print("Aborted")
 			tearDownClient(conn)
 			return
+		} else if err == liner.ErrPromptAborted {
+			fmt.Println("")
 		} else {
 			log.Printf("Error reading line: %s", err.Error())
 		}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -96,9 +96,9 @@
 			"branch": "master"
 		},
 		{
-			"importpath": "github.com/peterh/liner",
-			"repository": "https://github.com/peterh/liner",
-			"revision": "d5e5aeeb67ca5aeeddeb0b6c3af05421ff63a0b6",
+			"importpath": "github.com/martinpinto/liner",
+			"repository": "https://github.com/martinpinto/liner",
+			"revision": "488c6d3e1cd42b7f917c1eab570360f744fa508b",
 			"branch": "master"
 		},
 		{


### PR DESCRIPTION
Now it is only possible to quit skizze-cli with ctrl+d. Ctrl+c has been deactivated.