### PR TITLE
Fixed skizze-cli from crashing when len(fields) less than 5 while creating domains. Fix #104

### DIFF
--- a/src/skizze-cli/bridge/domain.go
+++ b/src/skizze-cli/bridge/domain.go
@@ -13,10 +13,8 @@ import (
 )
 
 func createDomain(fields []string, in *pb.Domain) error {
-	if len(fields) > 5 {
-		return fmt.Errorf("Too many arguments, expected 4 got %d", len(fields))
-	} else if len(fields) < 5 {
-		return fmt.Errorf("Not enough arguments, expected 5 got %d", len(fields))
+	if len(fields) != 5 {
+		return fmt.Errorf("Expected 5 arguments got %d", len(fields))
 	}
 
 	// FIXME make last 2 arguments optional

--- a/src/skizze-cli/bridge/domain.go
+++ b/src/skizze-cli/bridge/domain.go
@@ -14,7 +14,9 @@ import (
 
 func createDomain(fields []string, in *pb.Domain) error {
 	if len(fields) > 5 {
-		return fmt.Errorf("Too many argumets, expected 4 got %d", len(fields))
+		return fmt.Errorf("Too many arguments, expected 4 got %d", len(fields))
+	} else if len(fields) < 5 {
+		return fmt.Errorf("Not enough arguments, expected 5 got %d", len(fields))
 	}
 
 	// FIXME make last 2 arguments optional

--- a/src/skizze-cli/bridge/loop.go
+++ b/src/skizze-cli/bridge/loop.go
@@ -23,7 +23,7 @@ import (
 )
 
 const helpString = `
-  CREATE DOM  <name> <size> <maxUniqueItems>  Create a new Domain with options
+  CREATE DOM  <name> <maxUniqueItems> <rank>  Create a new Domain with options
   DESTROY DOM <name>                          Destroy a Domain
 
   CREATE CARD <name>                          Create a Cardinality Sketch

--- a/src/skizze-cli/bridge/loop.go
+++ b/src/skizze-cli/bridge/loop.go
@@ -57,7 +57,7 @@ EXAMPLES:
   CREATE DOM users 100 100000
   ADD DOM users neil seif martin conor neil conor seif seif seif
   GET FREQ users neil
-  GET RANK users      
+  GET RANK users
   GET CARD users
 `
 


### PR DESCRIPTION
Skizze CLI doesn't crash now when the length of the commands for creating domains is less than 5.